### PR TITLE
Branch 241009

### DIFF
--- a/cmd/migrate_command.go
+++ b/cmd/migrate_command.go
@@ -31,7 +31,7 @@ func (c *MigrateCommand) flags() *flag.FlagSet {
 	fs.BoolVar(&c.Verbose, "v", false, "whether show terraform logs")
 	fs.BoolVar(&c.Strict, "strict", false, "strict mode: API versions must be matched")
 	fs.StringVar(&c.workingDir, "working-dir", "", "path to Terraform configuration files")
-	fs.StringVar(&c.TargetProvider, "target-provider", "", "Specify the provider to migrate to. The allowed values are: azurerm and azapi. Default is azurerm.")
+	fs.StringVar(&c.TargetProvider, "to", "", "Specify the provider to migrate to. The allowed values are: azurerm and azapi. Default is azurerm.")
 
 	fs.Usage = func() { c.Ui.Error(c.Help()) }
 	return fs

--- a/cmd/migrate_command.go
+++ b/cmd/migrate_command.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"path"
 	"path/filepath"
 	"strings"
 
@@ -16,7 +17,7 @@ import (
 
 const filenameImport = "imports.tf"
 
-const tempDir = "temp"
+const tempFolderName = "aztfmigrate_temp"
 
 type MigrateCommand struct {
 	Ui             cli.Ui
@@ -41,6 +42,11 @@ func (c *MigrateCommand) Run(args []string) int {
 	// AzureRM provider will honor env.var "AZURE_HTTP_USER_AGENT" when constructing for HTTP "User-Agent" header.
 	// #nosec G104
 	_ = os.Setenv("AZURE_HTTP_USER_AGENT", "mig")
+	// The following env.vars are used to disable enhanced validation and skip provider registration, to speed up the process.
+	// #nosec G104
+	_ = os.Setenv("ARM_PROVIDER_ENHANCED_VALIDATION", "false")
+	// #nosec G104
+	_ = os.Setenv("ARM_SKIP_PROVIDER_REGISTRATION", "true")
 	f := c.flags()
 	if err := f.Parse(args); err != nil {
 		c.Ui.Error(fmt.Sprintf("Error parsing command-line flags: %s", err))
@@ -96,16 +102,24 @@ func (c *MigrateCommand) MigrateResources(terraform *tf.Terraform, resources []t
 
 	workingDirectory := terraform.GetWorkingDirectory()
 	// write empty config to temp dir for import
-	tempDirectoryCreate(workingDirectory)
-	tempPath := filepath.Join(workingDirectory, tempDir)
-	tempTerraform, err := tf.NewTerraform(tempPath, c.Verbose)
+	tempDir := filepath.Join(workingDirectory, tempFolderName)
+	if err := os.MkdirAll(tempDir, 0750); err != nil {
+		log.Fatalf("creating temp workspace %q: %+v", tempDir, err)
+	}
+	defer func() {
+		err := os.RemoveAll(path.Join(tempDir, "terraform.tfstate"))
+		if err != nil {
+			log.Printf("[ERROR] removing temp workspace %q: %+v", tempDir, err)
+		}
+	}()
+	tempTerraform, err := tf.NewTerraform(tempDir, c.Verbose)
 	if err != nil {
 		log.Fatal(err)
 	}
 
 	log.Printf("[INFO] generating import config...")
-	config := importConfig(resources, c.TargetProvider)
-	if err = os.WriteFile(filepath.Join(tempPath, filenameImport), []byte(config), 0600); err != nil {
+	config := importConfig(resources)
+	if err = os.WriteFile(filepath.Join(tempDir, filenameImport), []byte(config), 0600); err != nil {
 		log.Fatal(err)
 	}
 
@@ -116,8 +130,6 @@ func (c *MigrateCommand) MigrateResources(terraform *tf.Terraform, resources []t
 			log.Printf("[ERROR] %+v", err)
 		}
 	}
-
-	tempDirectoryCleanup(workingDirectory)
 
 	log.Printf("[INFO] updating config...")
 	updateResources := make([]types.AzapiUpdateResource, 0)
@@ -169,20 +181,19 @@ func (c *MigrateCommand) MigrateResources(terraform *tf.Terraform, resources []t
 	}
 }
 
-func importConfig(resources []types.AzureResource, targetProvider string) string {
+func importConfig(resources []types.AzureResource) string {
 	const providerConfig = `
-provider "azurerm" {
-  features {}
-  subscription_id = "%s"
-}
-`
-	const AzapiProviderConfig = `
 terraform {
   required_providers {
     azapi = {
       source = "Azure/azapi"
     }
   }
+}
+
+provider "azurerm" {
+  features {}
+  subscription_id = "%s"
 }
 
 provider "azapi" {
@@ -193,52 +204,26 @@ provider "azapi" {
 	for _, r := range resources {
 		config += r.EmptyImportConfig()
 	}
-	if targetProvider == "azurerm" {
-		subscriptionId := ""
-		for _, r := range resources {
-			switch resource := r.(type) {
-			case *types.AzapiResource:
-				for _, instance := range resource.Instances {
-					if strings.HasPrefix(instance.ResourceId, "/subscriptions/") {
-						subscriptionId = strings.Split(instance.ResourceId, "/")[2]
-						break
-					}
-				}
-			case *types.AzapiUpdateResource:
-				if strings.HasPrefix(resource.Id, "/subscriptions/") {
-					subscriptionId = strings.Split(resource.Id, "/")[2]
+	subscriptionId := ""
+	for _, r := range resources {
+		switch resource := r.(type) {
+		case *types.AzapiResource:
+			for _, instance := range resource.Instances {
+				if strings.HasPrefix(instance.ResourceId, "/subscriptions/") {
+					subscriptionId = strings.Split(instance.ResourceId, "/")[2]
+					break
 				}
 			}
-			if subscriptionId != "" {
-				break
+		case *types.AzapiUpdateResource:
+			if strings.HasPrefix(resource.Id, "/subscriptions/") {
+				subscriptionId = strings.Split(resource.Id, "/")[2]
 			}
 		}
-		config = fmt.Sprintf(providerConfig, subscriptionId) + config
-	} else {
-		config = AzapiProviderConfig + config
+		if subscriptionId != "" {
+			break
+		}
 	}
+	config = fmt.Sprintf(providerConfig, subscriptionId) + config
 
 	return config
-}
-
-func tempDirectoryCreate(workingDirectory string) {
-	tempPath := filepath.Join(workingDirectory, tempDir)
-	if _, err := os.Stat(tempPath); !os.IsNotExist(err) {
-		if err := os.RemoveAll(tempPath); err != nil {
-			log.Fatalf("error deleting %s: %+v", tempPath, err)
-		}
-	}
-	if err := os.MkdirAll(tempPath, 0750); err != nil {
-		log.Fatalf("creating temp workspace %q: %+v", tempPath, err)
-	}
-}
-
-func tempDirectoryCleanup(workingDirectory string) {
-	tempPath := filepath.Join(workingDirectory, tempDir)
-	// cleanup temp folder
-	if _, err := os.Stat(tempPath); !os.IsNotExist(err) {
-		if err := os.RemoveAll(tempPath); err != nil {
-			log.Printf("[WARN] error deleting %s: %+v", tempPath, err)
-		}
-	}
 }

--- a/cmd/migrate_command_test.go
+++ b/cmd/migrate_command_test.go
@@ -2,14 +2,6 @@ package cmd_test
 
 import (
 	"fmt"
-	"log"
-	"math/rand"
-	"os"
-	"path/filepath"
-	"strings"
-	"testing"
-	"time"
-
 	"github.com/Azure/aztfmigrate/azurerm"
 	"github.com/Azure/aztfmigrate/cmd"
 	"github.com/Azure/aztfmigrate/tf"
@@ -17,6 +9,12 @@ import (
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclwrite"
 	"github.com/mitchellh/cli"
+	"log"
+	"math/rand"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
 )
 
 func TestMigrate_basic(t *testing.T) {
@@ -192,10 +190,6 @@ provider "azurerm" {
 		t.Fatalf("expect no plan-diff, but got %v", changes)
 	}
 
-}
-
-func init() {
-	rand.Seed(time.Now().UnixNano())
 }
 
 func tempDir(t *testing.T) string {

--- a/cmd/plan_command.go
+++ b/cmd/plan_command.go
@@ -28,7 +28,7 @@ func (c *PlanCommand) flags() *flag.FlagSet {
 	fs.BoolVar(&c.Verbose, "v", false, "whether show terraform logs")
 	fs.BoolVar(&c.Strict, "strict", false, "strict mode: API versions must be matched")
 	fs.StringVar(&c.workingDir, "working-dir", "", "path to Terraform configuration files")
-	fs.StringVar(&c.TargetProvider, "target-provider", "", "Specify the provider to migrate to. The allowed values are: azurerm and azapi. Default is azurerm.")
+	fs.StringVar(&c.TargetProvider, "to", "", "Specify the provider to migrate to. The allowed values are: azurerm and azapi. Default is azurerm.")
 	fs.Usage = func() { c.Ui.Error(c.Help()) }
 	return fs
 }

--- a/cmd/plan_command_test.go
+++ b/cmd/plan_command_test.go
@@ -1,15 +1,12 @@
 package cmd_test
 
 import (
-	"math/rand"
-	"os"
-	"path/filepath"
-	"testing"
-	"time"
-
 	"github.com/Azure/aztfmigrate/cmd"
 	"github.com/Azure/aztfmigrate/tf"
 	"github.com/mitchellh/cli"
+	"os"
+	"path/filepath"
+	"testing"
 )
 
 func TestPlan_basic(t *testing.T) {
@@ -94,8 +91,4 @@ func planTestCase(t *testing.T, content string, expectMigratedAddresses []string
 			t.Fatalf("expect %s not migrated, but got it migrated", r.OldAddress(nil))
 		}
 	}
-}
-
-func init() {
-	rand.Seed(time.Now().UnixNano())
 }

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/Azure/aztfmigrate
 
-go 1.21
+go 1.22
 
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.9.2

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/Azure/aztfmigrate
 
-go 1.22
+go 1.22.0
 
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.9.2

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/Azure/aztfmigrate
 
-go 1.22.0
-
-toolchain go1.23.1
+go 1.21
 
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.9.2

--- a/readme.md
+++ b/readme.md
@@ -15,7 +15,7 @@ Available commands are:
     version    Displays the version of the migration tool
 ```
 
-1. Run `aztfmigrate plan -target-provider=azurerm` under your terraform working directory, 
+1. Run `aztfmigrate plan -to=azurerm` under your terraform working directory, 
    it will list all resources that can be migrated from `azapi` provider to `azurerm` provider.
    The Terraform addresses listed in file `aztfmigrate.ignore` will be ignored during migration.
 ```
@@ -33,7 +33,7 @@ azapi_resource.test: input properties not supported: [], output properties not s
 
 The following resources will be ignored in migration:
    ```
-2. Run `aztfmigrate migrate -target-provider=azurerm` under your terraform working directory, 
+2. Run `aztfmigrate migrate -to=azurerm` under your terraform working directory, 
    it will migrate above resources from `azapi` provider to `azurerm` provider, 
    both terraform configuration and state.
    The Terraform addresses listed in file `aztfmigrate.ignore` will be ignored during migration.


### PR DESCRIPTION
This PR made the following changes:
1. Rename the `-target-provider` to `-to` to avoid confusion.
2. Reuse the `temp` folder which contains the initialized provider binaries to improve performance.