### PR TITLE
support `moved` block in migration flow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 FEATURES:
 - Support `-var-file` option to specify the path to the terraform variable file.
 - Support migrating resources from `azurerm` provider to `azapi` provider.
+- When migrating resources from `azurerm` provider to `azapi` provider, it will generate `moved` block to modify the terraform state.
 
 ## v2.0.0-beta
 

--- a/cmd/migrate_command.go
+++ b/cmd/migrate_command.go
@@ -168,9 +168,11 @@ func (c *MigrateCommand) MigrateResources(terraform *tf.Terraform, resources []t
 	for _, r := range resources {
 		if r.IsMigrated() {
 			log.Printf("[INFO] removing %s from config", r.OldAddress(nil))
-			importBlock := r.ImportBlock()
-			removedBlock := r.RemovedBlock()
-			if err := types.ReplaceResourceBlock(workingDirectory, r.OldAddress(nil), []*hclwrite.Block{removedBlock, importBlock, r.MigratedBlock()}); err != nil {
+			stateUpdateBlocks := r.StateUpdateBlocks()
+			newBlocks := make([]*hclwrite.Block, 0)
+			newBlocks = append(newBlocks, stateUpdateBlocks...)
+			newBlocks = append(newBlocks, r.MigratedBlock())
+			if err := types.ReplaceResourceBlock(workingDirectory, r.OldAddress(nil), newBlocks); err != nil {
 				log.Printf("[ERROR] error removing %s from state: %+v", r.OldAddress(nil), err)
 			}
 		}

--- a/types/azapi_resource.go
+++ b/types/azapi_resource.go
@@ -29,6 +29,13 @@ type AzapiResource struct {
 	Migrated         bool
 }
 
+func (r *AzapiResource) StateUpdateBlocks() []*hclwrite.Block {
+	blocks := make([]*hclwrite.Block, 0)
+	blocks = append(blocks, r.removedBlock())
+	blocks = append(blocks, r.importBlock())
+	return blocks
+}
+
 func (r *AzapiResource) Outputs() []Output {
 	res := make([]Output, 0)
 	for _, instance := range r.Instances {
@@ -49,7 +56,7 @@ func (r *AzapiResource) IsMigrated() bool {
 	return r.Migrated
 }
 
-func (r *AzapiResource) ImportBlock() *hclwrite.Block {
+func (r *AzapiResource) importBlock() *hclwrite.Block {
 	importBlock := hclwrite.NewBlock("import", nil)
 	if r.IsMultipleResources() {
 		forEachMap := make(map[string]cty.Value)
@@ -72,7 +79,7 @@ func (r *AzapiResource) ImportBlock() *hclwrite.Block {
 	return importBlock
 }
 
-func (r *AzapiResource) RemovedBlock() *hclwrite.Block {
+func (r *AzapiResource) removedBlock() *hclwrite.Block {
 	removedBlock := hclwrite.NewBlock("removed", nil)
 	removedBlock.Body().SetAttributeTraversal("from", hcl.Traversal{hcl.TraverseRoot{Name: "azapi_resource"}, hcl.TraverseAttr{Name: r.Label}})
 	removedLifecycleBlock := hclwrite.NewBlock("lifecycle", nil)

--- a/types/azapi_update_resource.go
+++ b/types/azapi_update_resource.go
@@ -30,6 +30,12 @@ type AzapiUpdateResource struct {
 	OutputProperties []string
 }
 
+func (r *AzapiUpdateResource) StateUpdateBlocks() []*hclwrite.Block {
+	blocks := make([]*hclwrite.Block, 0)
+	blocks = append(blocks, r.removedBlock())
+	return blocks
+}
+
 func (r *AzapiUpdateResource) Outputs() []Output {
 	res := make([]Output, 0)
 	res = append(res, r.outputs...)
@@ -63,11 +69,7 @@ func (r *AzapiUpdateResource) GenerateNewConfig(terraform *tf.Terraform) error {
 	return nil
 }
 
-func (r *AzapiUpdateResource) ImportBlock() *hclwrite.Block {
-	return nil
-}
-
-func (r *AzapiUpdateResource) RemovedBlock() *hclwrite.Block {
+func (r *AzapiUpdateResource) removedBlock() *hclwrite.Block {
 	removedBlock := hclwrite.NewBlock("removed", nil)
 	removedBlock.Body().SetAttributeTraversal("from", hcl.Traversal{hcl.TraverseRoot{Name: "azapi_update_resource"}, hcl.TraverseAttr{Name: r.OldLabel}})
 	removedLifecycleBlock := hclwrite.NewBlock("lifecycle", nil)

--- a/types/azure_resource.go
+++ b/types/azure_resource.go
@@ -16,8 +16,7 @@ type AzureResource interface {
 	GenerateNewConfig(terraform *tf.Terraform) error
 	EmptyImportConfig() string
 
-	ImportBlock() *hclwrite.Block
-	RemovedBlock() *hclwrite.Block
+	StateUpdateBlocks() []*hclwrite.Block
 	MigratedBlock() *hclwrite.Block
 
 	IsMigrated() bool

--- a/types/hcl.go
+++ b/types/hcl.go
@@ -96,7 +96,7 @@ func ReplaceGenericOutputs(workingDirectory string, outputs []Output) error {
 			continue
 		}
 		for _, block := range f.Body().Blocks() {
-			if block.Type() == "removed" || block.Type() == "import" {
+			if block.Type() == "removed" || block.Type() == "import" || block.Type() == "moved" {
 				continue
 			}
 			if block != nil {


### PR DESCRIPTION
This PR updates the azurerm to azapi migration flow, it generates `moved` block instead of `removed` + `import` block to modify terraform state.