### PR TITLE
bugfix: import config is not initialized correctly

### DIFF
--- a/cmd/migrate_command.go
+++ b/cmd/migrate_command.go
@@ -222,6 +222,13 @@ func ImportConfig(resources []types.AzureResource, terraformBlock *hclwrite.Bloc
 			if strings.HasPrefix(resource.Id, "/subscriptions/") {
 				subscriptionId = strings.Split(resource.Id, "/")[2]
 			}
+		case *types.AzurermResource:
+			for _, instance := range resource.Instances {
+				if strings.HasPrefix(instance.ResourceId, "/subscriptions/") {
+					subscriptionId = strings.Split(instance.ResourceId, "/")[2]
+					break
+				}
+			}
 		}
 		if subscriptionId != "" {
 			break


### PR DESCRIPTION
The azurerm provider could not be init correctly if the subscription_id is missing, this PR fixes it.